### PR TITLE
⚡ Optimize SingleFrame rendering loop in renderer

### DIFF
--- a/renderer/src/render.rs
+++ b/renderer/src/render.rs
@@ -21,8 +21,12 @@ pub trait Render {
                 self.render_by_id(animation, *sprite_id, &transform, &mut reader, frame);
             }
             SpritePayload::SingleFrame(sprite_ids, _) => {
+                let transform = reader
+                    .read_transformation()
+                    .expect("transformation should be present")
+                    .combine(&transform);
                 for sprite_id in sprite_ids {
-                    self.render_by_id(animation, *sprite_id, &transform, &mut reader, frame);
+                    self.render_at(animation, *sprite_id, transform.clone(), frame);
                 }
             }
             SpritePayload::Indexed(frame_pos, sprite_info, action_info) => {
@@ -39,6 +43,20 @@ pub trait Render {
         }
     }
 
+    fn render_at(
+        &mut self,
+        anm: &Animation,
+        id: i16,
+        transform: SpriteTransform,
+        frame: u32,
+    ) {
+        if let Some(sprite) = anm.sprites.get(&id) {
+            self.render_sprite(anm, sprite, transform, frame);
+        } else if let Some(shape) = anm.shapes.get(&id) {
+            self.render(shape, transform);
+        }
+    }
+
     fn render_by_id(
         &mut self,
         anm: &Animation,
@@ -49,13 +67,9 @@ pub trait Render {
     ) {
         let transform = reader
             .read_transformation()
-            .expect("transormation should be present")
+            .expect("transformation should be present")
             .combine(parent);
-        if let Some(sprite) = anm.sprites.get(&id) {
-            self.render_sprite(anm, sprite, transform, frame);
-        } else if let Some(shape) = anm.shapes.get(&id) {
-            self.render(shape, transform);
-        }
+        self.render_at(anm, id, transform, frame);
     }
 }
 


### PR DESCRIPTION
The `SingleFrame` payload handling in `renderer/src/render.rs` was unnecessarily repeating transformation reading and matrix multiplication for each sprite in the group. By moving these operations outside the loop, we avoid redundant I/O and calculations.

Additionally, I've refactored the `Render` trait to include a `render_at` method, which is now used by both `render_by_id` and the optimized `SingleFrame` loop, improving code clarity and maintainability.

Measured Improvement:
While local benchmark execution was hindered by environment timeouts, the optimization directly removes O(N) redundant operations (where N is the number of sprites in a SingleFrame group), which is a clear theoretical improvement for complex animations.

I have also fixed a persistent typo ("transormation") in the affected file.

---
*PR created automatically by Jules for task [7487956969835238569](https://jules.google.com/task/7487956969835238569) started by @jac3km4*